### PR TITLE
Added helpers in Note model to access taggings as a tagger or a refer…

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,11 @@
 class Note < ApplicationRecord
   belongs_to :user
   belongs_to :folder, optional: true
-  has_many :taggings
+
+  # has_many :taggings, dependent: :destroy
+  # tried it all functions work but dependent destroy generates a query with note.tagging_id
+
+  # So seperated the taggings type
+  has_many :taggings_as_tagger, class_name: "Tagging", foreign_key: 'tagger_id', dependent: :destroy
+  has_many :taggings_as_reference, class_name: "Tagging", foreign_key: 'reference_id', dependent: :destroy
 end


### PR DESCRIPTION
Added helpers in Note model to access taggings as a tagger or a reference, before dependent destroy was not working, now fixed